### PR TITLE
Fixed needs.json

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 
 * Bugfix: Fixed system python version compatiable. :issue:`42`
 * Bugfix: Fixed pythonPath from user input saved correctly in workspace setting. :issue:`45`
+* Bugfix: Fixed needs.json location not in sync between extension and needls and create needs.json if not exsits after extension activation. :issue:`37`
 
 
 0.0.15


### PR DESCRIPTION
Fix #37

- Fixed created needs.json not in snyc between extension and needls

- Checked needs.json after extension activated, created if not exists